### PR TITLE
Correction de la disposition pour le pied de page

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -26,7 +26,7 @@ function startInjection() {
 
 	let zModules = [
 		{
-			name: "Zeste datas",
+			name: "Zeste data",
 			js: [getZesteFilesJS, getZesteConfig],
 		},
 		{
@@ -38,7 +38,7 @@ function startInjection() {
 			js: ["modules/fixes/fixes.js"],
 		},
 		{
-			name: "Forum text-editor",
+			name: "Forum text editor",
 			js: ["modules/text_editor/edit_bar.js"],
 			css: ["modules/text_editor/edit_bar.css"],
 			require: ["text_editor"],
@@ -50,7 +50,7 @@ function startInjection() {
 			require: ["zeste"],
 		},
 		{
-			name: "Submisions style",
+			name: "Submissions style",
 			css: ["modules/submissions/submissions.css"],
 			require: ["submissions"],
 		},
@@ -77,6 +77,7 @@ function startInjection() {
 			name: "Focus mode",
 			css: ["modules/focus_mode/focus.css"],
 			js: ["modules/focus_mode/focus.js"],
+			require: ["focus_mode"],
 		},
 	];
 

--- a/inject.js
+++ b/inject.js
@@ -105,8 +105,7 @@ function startInjection() {
 						link.rel = "stylesheet";
 						link.type = "text/css";
 						link.href = chrome.extension.getURL(cssContent);
-						head.appendChild(link);
-						$(body).append($(link).clone());
+						body.appendChild(link);
 					}
 				}
 				if (mod.internal) {

--- a/modules/focus_mode/focus.css
+++ b/modules/focus_mode/focus.css
@@ -8,6 +8,7 @@ label[for="focusMode"] {
 	display: inline-block;
 	height: 32px;
 	width: 32px;
+	margin-right: 10px;
 	cursor: pointer;
 	position: relative;
 }

--- a/modules/focus_mode/focus.js
+++ b/modules/focus_mode/focus.js
@@ -1,8 +1,12 @@
 $(function() {
-	$(".links-box-middle + td").width(140).prepend(
+	let cell = $(".links-box-middle + td");
+	if ($("#taskSaved").length) {
+	   cell.width(140);
+   }
+   cell.prepend(
 		$('<input type="checkbox" id="focusMode" /><label for="focusMode"><div></div><span>Mode sans distraction</span></label>')
 	);
-	var customCss = 'label[for="focusMode"] div { background-image: url("' + zesteFiles["focus"] + '"); }\n';
+	let customCss = 'label[for="focusMode"] div { background-image: url("' + zesteFiles["focus"] + '"); }\n';
 	$( "<style>" + customCss + "</style>" ).appendTo("head");
 	$("#focusMode").change(function() {
 		$(".menucol, .return-link-box, .arrowIcon")[this.checked ? 'fadeOut' : 'fadeIn']();

--- a/modules/focus_mode/focus.js
+++ b/modules/focus_mode/focus.js
@@ -1,14 +1,16 @@
 $(function() {
-	let cell = $(".links-box-middle + td");
-	if ($("#taskSaved").length) {
-	   cell.width(140);
+	if ($("#task-tabs").length) {
+	   let cell = $(".links-box-middle + td");
+	   if ($("#taskSaved").length) {
+	      cell.width(140);
+      }
+      cell.prepend(
+		   $('<input type="checkbox" id="focusMode" /><label for="focusMode"><div></div><span>Mode sans distraction</span></label>')
+	   );
+	   let customCss = 'label[for="focusMode"] div { background-image: url("' + zesteFiles["focus"] + '"); }\n';
+	   $( "<style>" + customCss + "</style>" ).appendTo("head");
+	   $("#focusMode").change(function() {
+		   $(".menucol, .return-link-box, .arrowIcon")[this.checked ? 'fadeOut' : 'fadeIn']();
+	   });
    }
-   cell.prepend(
-		$('<input type="checkbox" id="focusMode" /><label for="focusMode"><div></div><span>Mode sans distraction</span></label>')
-	);
-	let customCss = 'label[for="focusMode"] div { background-image: url("' + zesteFiles["focus"] + '"); }\n';
-	$( "<style>" + customCss + "</style>" ).appendTo("head");
-	$("#focusMode").change(function() {
-		$(".menucol, .return-link-box, .arrowIcon")[this.checked ? 'fadeOut' : 'fadeIn']();
-	});
 });

--- a/modules/focus_mode/focus.js
+++ b/modules/focus_mode/focus.js
@@ -1,5 +1,5 @@
 $(function() {
-	if ($("#task-tabs").length) {
+	if ($(".heading-link-box.with-title").length) {
 	   let cell = $("#heading-link-box .links-box-middle + td");
 	   if ($("#taskSaved").length) {
 	      cell.width(140);

--- a/modules/focus_mode/focus.js
+++ b/modules/focus_mode/focus.js
@@ -1,6 +1,6 @@
 $(function() {
 	if ($("#task-tabs").length) {
-	   let cell = $(".links-box-middle + td");
+	   let cell = $("#heading-link-box .links-box-middle + td");
 	   if ($("#taskSaved").length) {
 	      cell.width(140);
       }

--- a/modules/task_saver/button.css
+++ b/modules/task_saver/button.css
@@ -8,7 +8,7 @@ label[for="taskSaved"] {
 	display: inline-block;
 	height: 32px;
 	width: 32px;
-	margin: 0px 10px;
+	margin-right: 10px;
 	cursor: pointer;
 	position: relative;
 }

--- a/modules/task_saver/internal.js
+++ b/modules/task_saver/internal.js
@@ -15,7 +15,15 @@ function taskSaverInternal() {
 				.end()  //again go back to selected element
 				.text();
 
-		var idTask = getParameterByName("idTask"), idChapter = getParameterByName("idChapter");
+      var variables;
+      $("script:not([src])").each(function() {
+         var scriptContent = $(this).text();
+         if (scriptContent.match(/^\s*var\s*idTask\s*=/)) {
+            variables = scriptContent;
+         }
+      });
+      eval(variables);
+
 		var req = {
 			"req": "on_task",
 			"task": idTask,

--- a/modules/task_saver/internal.js
+++ b/modules/task_saver/internal.js
@@ -15,8 +15,7 @@ function taskSaverInternal() {
 				.end()  //again go back to selected element
 				.text();
 
-		var variables = $("script[src=\"../ext/jquery/jquery.blockUI.js\"] + script").text();
-		eval(variables);
+		var idTask = getParameterByName("idTask"), idChapter = getParameterByName("idChapter");
 		var req = {
 			"req": "on_task",
 			"task": idTask,

--- a/modules/zeste_style/zestes.css
+++ b/modules/zeste_style/zestes.css
@@ -1,6 +1,21 @@
 /*
 	Menus colonnes
 */
+@media screen and (min-width: 1090px) {
+	.menucol {
+		position: static;
+		height: auto;
+		float: left;
+		clear: left;
+		background: #f0f0f0;
+	}
+}
+@media screen and (min-width: 1290px) {
+	.menucol + .menucol {
+		float: right;
+		clear: right;
+	}
+}
 .menucol aside {
 	border-radius: 0px!important;
 	margin: 0px;
@@ -9,6 +24,8 @@
 	padding: 0px;
 	padding-bottom: 12px;
 	z-index: 2;
+	float: none;
+	position: static;
 }
 .menuLogin {
 	padding-bottom: 0px!important;
@@ -81,8 +98,14 @@ html[lang=fr] .menu-language-select {
 	Colonnes petites
 */
 @media screen and (max-width: 1089px) {
+	.menucolContainer {
+		text-align: center;
+	}
 	.menucol {
+		display: inline-block;
 		padding-bottom: 0px;
+		background: #f7f7f7;
+		text-align: left;
 	}
 	.menucol aside {
 		padding-bottom: 0px;
@@ -263,15 +286,17 @@ html[lang=fr] .menu-language-select {
 	padding: 0px;
 }
 
-
 /*
 	Footer
 */
 #return-link-box {
-	width: 100%;
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	margin-bottom: 0;
 	border-top: 3px solid #f8ad32;
 	background: #084561;
-	height: 40px;
 	line-height: 40px;
 	z-index: 0;
 	color: #eee;
@@ -287,6 +312,10 @@ html[lang=fr] .menu-language-select {
 #return-link-box td:not(.links-box-middle) {
 	display: none;
 }
+#return-link-box .direction-box h1 {
+	margin: 0;
+}
+
 /* 
 	Main
 */
@@ -297,14 +326,24 @@ main, body {
 	color: black;
 	padding-bottom: 0px;
 }
+body {
+	position: absolute;
+	width: 100%;
+	min-height: 100%;
+	padding-bottom: 60px;
+	box-sizing: border-box;
+}
+main {
+	text-align: center;
+}
 .bottomBackground {
 	display: none;
 }
 main a:link, main a:visited {
 	color: #1088bf;
-	/*text-decoration: underline;*/
 }
 .contentsbox {
+	display: inline-block; /* Avoids clearing below the menus */
 	background-color: transparent;
 	border: none;
 }

--- a/modules/zeste_style/zestes.css
+++ b/modules/zeste_style/zestes.css
@@ -333,9 +333,6 @@ body {
 	padding-bottom: 60px;
 	box-sizing: border-box;
 }
-main {
-	text-align: center;
-}
 .bottomBackground {
 	display: none;
 }
@@ -343,7 +340,7 @@ main a:link, main a:visited {
 	color: #1088bf;
 }
 .contentsbox {
-	display: inline-block; /* Avoids clearing below the menus */
+	overflow-y: hidden; /* Avoids clearing below the menus */
 	background-color: transparent;
 	border: none;
 }

--- a/modules/zeste_style/zestes.js
+++ b/modules/zeste_style/zestes.js
@@ -2,18 +2,12 @@ var zesteJSModuleMain = function() {
 	$("html").attr("zeste", "true");
 
 	/*
-		Change footer location, set page min-height and column size
+		Fix menu structure
 	*/
-	var footer = document.getElementById("return-link-box");
-	if (footer) {
-		document.body.appendChild(footer);
-
-		$("#return-link-box").css("display", "none");
-
-		var body = document.body, html = document.documentElement;
-		var height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
-		$("main").css("min-height", height);
-		$("#return-link-box").css("display", "block");
+	var menucol = $('.menucol');
+	if (menucol.length == 1) {
+		menucol.wrap($('<div class="menucolContainer">'));
+		$('<div class="menucol">').append($('.menuCommunity')).insertAfter(menucol);
 	}
 
 	/*
@@ -22,10 +16,10 @@ var zesteJSModuleMain = function() {
 	if ($("#heading-link-box span.direction-sep").size()) {
 		$("#heading-link-box").addClass("menuLiensTabs");
 		$("#heading-link-box a").each(function() {
-		   if (this.href == window.location.href) {
-		      $(this).parent().addClass("menuLiensActuel");
-	      }
-      });
+			if (this.href == window.location.href) {
+				$(this).parent().addClass("menuLiensActuel");
+			}
+		});
 	}
 	$(".chapters-list-pbs").parent().addClass("trChapter");
 
@@ -186,8 +180,11 @@ var zesteJSModuleMain = function() {
 	}
 	$('.classement_row_data td[colspan="4"]').attr("colspan", "5");
 
+	/*
+		Easter eggs
+	*/
 	if ($("#homeContents").size()) {
-		var the_game = $("<h4>THE GAME</h4>").css("color", "transparent").css("font-size", "2rem").css("text-align", "center");
+		var the_game = $("<h4>THE GAME</h4>").css({"color": "transparent", "font-size": "2rem", "text-align": "center", "margin-bottom": "-2rem"});
 		$(".contentsbox").append(the_game);
 	}
 	$(".classement_row_data td").each(function(id) {

--- a/pages/options.html
+++ b/pages/options.html
@@ -36,8 +36,12 @@
 						<label for="enable_text_editor">Boite à outils améliorée pour le forum</label>
 					</li>
 					<li>
+						<input type="checkbox" id="enable_focus_mode" data-cfg="enable_focus_mode" />
+						<label for="enable_focus_mode">Bouton pour afficher les sujets sans distraction</label>
+					</li>
+					<li>
 						<input type="checkbox" id="enable_task_saver" data-cfg="enable_task_saver" />
-						<label for="enable_task_saver">Bouton de sauvegarde hors ligne</label>
+						<label for="enable_task_saver">Bouton de sauvegarde des sujets hors ligne</label>
 					</li>
 					<li>
 						<input type="checkbox" id="enable_follow_users" data-cfg="enable_follow_users" />

--- a/shared.js
+++ b/shared.js
@@ -183,6 +183,7 @@ var config = {
 		enable_compact: false,
 		compact_rm_menus: true,
 		enable_follow_users: true,
+		enable_focus_mode: true,
 	},
 	get: function(callback) {
 		var configObj = this;


### PR DESCRIPTION
Comme je te l’avais indiqué, j’ai travaillé sur la disposition pour le pied de page. Il a fallu toucher à la structure des menus (il aurait été approprié de changer ça directement dans le code du site), mais ça ne fait pas un code très long. J’ai aussi fait attention à ce que tout marche bien en vue étroite.

Avant cela, j’ai rajouté la possibilité de désactiver le mode focus (que j’appelle « sans distraction » comme dans WordPress). Ce n’est pas très utile à mon avis, mais j’ai voulu être cohérent avec le reste… La liste des options a aussi l’intérêt de montrer quelles sont les différentes fonctionnalités de l’extension donc ça me va bien de la compléter.

Puis j’ai fait quelques petites corrections notamment pour le mode sans distraction.

Merci de fusionner et de publier ! À priori, j’ai terminé mon travail sur cette extension.